### PR TITLE
fix: check if child is using memo()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ export default class StepWizard extends PureComponent {
     }
 
     // Allows for using HTML elements as a step
-    isReactComponent = type => typeof type === 'function'
+    isReactComponent = child => typeof child === 'function' || typeof child.type === 'function'
 
     /** Render */
     render() {


### PR DESCRIPTION
when the child uses memo function the return of type is an object
that contains the following structure

```
{
  "$$typeof": Symbol(react.memo)
  compare: null
  type: function Step()
}
```
so we needed to check deeply if it has a function type

resolve #27 