### PR TITLE
Correctly indicate types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.3.2",
   "description": "A modern flexible step wizard component built for React",
   "main": "dist/react-step-wizard.min.js",
-  "typings": "dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "start": "export NODE_ENV=development; ./scripts/run.dev.js",
     "dev": "rollup --config rollup.config.js --watch",


### PR DESCRIPTION
Types should be indicated by `types`, not `typings`