### PR TITLE
Typescript: Added React.ReactElement type as a possibility for StepWizardProps children

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ export type StepWizardProps = Partial<{
     exitLeft?: string
   }
 
-  children: JSX.Element | JSX.Element[]
+  children: JSX.Element | JSX.Element[] | React.ReactElement
 }>
 
 export type StepWizardChildProps<T extends Record<string, any> = {}> = {


### PR DESCRIPTION
when using typescript, currently one is not able to pull the `<StepWizard>` props out for any children directly when destructuring. For example:

```ts
 <StepWizard>
      {(stepWizzardProps: StepWizardChildProps) => (
          <Step1
              someProp={true}
              anotherProp={"here"}
              onNextClick={stepWizzardProps.nextStep}
            />
            <Step2 />
      )}
</StepWizard>

// Step1.ts
type Step1Props = {
  someProp: boolean;
  anotherProp: string;
  onNextClick: () => void;
}

const Step1 = ({ someProp, anotherProp, onNextClick } : Step1Props) => {
  return (
    <div>
      <button onClick={onNextClick}>Click Me</button>
    </div>
  );
};
```