### PR TITLE
Fallback to step1 when no hash is found. Only show console.error mess…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,9 +77,7 @@ export default class StepWizard extends PureComponent {
     }
 
     onHashChange = () => {
-        const next = this.state.hashKeys[this.getHash()];
-
-        if (next !== undefined) this.setActiveStep(next);
+        this.setActiveStep(this.state.hashKeys[this.getHash()] || 0);
     }
 
     isInvalidStep = next => (next < 0 || next >= this.totalSteps)
@@ -88,7 +86,9 @@ export default class StepWizard extends PureComponent {
         const active = this.state.activeStep;
         if (active === next) return;
         if (this.isInvalidStep(next)) {
-            console.error(`${next + 1} is an invalid step`);
+            if (process.env.NODE_ENV !== 'production') {
+                console.error(`${next + 1} is an invalid step`);
+            }
             return;
         }
 


### PR DESCRIPTION
This fixes [this issue](https://github.com/jcmcneal/react-step-wizard/issues/46).

Falls back to step1 when user clicks browser back button past step2. Also not showing console messages in production mode.