### PR TITLE
Add support for named steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ For example:
 | initialStep   | `integer`  | 1         |
 | instance      | `function` |           | Provides an instance of `StepWizard` to control from anywhere in your app                |
 | isHashEnabled | `bool`     | false     | Persists the current step in the URL (hash)                                              |
-| isHashEnabled | `bool`     | false     | Allows for setting names for steps                                                       |
 | isLazyMount   | `boolean`  | false     | Only mounts the child component when `isActive` is true                                  |
 | nav           | `node`     |           | Create a custom navigation component to include in the wizard                            |
 | onStepChange  | `function` |           | Callback for step change                                                                 |
@@ -77,17 +76,18 @@ For example:
 
 #### Props Accessible On Each Child (_Step_) Component
 
-| Prop         | Data Type  | Parameters                     |
-| ------------ | ---------- | ------------------------------ |
-| isActive     | `boolean`  |
-| currentStep  | `integer`  |
-| totalSteps   | `integer`  |
-| firstStep    | `function` |
-| lastStep     | `function` |
-| nextStep     | `function` |
-| previousStep | `function` |
-| goToStep     | `function` | `integer` : `goToStep(3)`      |
-| goToStep     | `function` | `string` : `goToStep('step3')` |
+| Prop          | Data Type  | Parameters                            |
+| ------------- | ---------- | ------------------------------------- |
+| isActive      | `boolean`  |
+| currentStep   | `integer`  |
+| totalSteps    | `integer`  |
+| firstStep     | `function` |
+| lastStep      | `function` |
+| nextStep      | `function` |
+| previousStep  | `function` |
+| goToStep      | `function` | `integer` : `goToStep(3)`             |
+| goToStep      | `function` | `string` : `goToStep('step3')`        |
+| goToNamedStep | `function` | `string` : `goToNamedStep('contact')` |
 
 ---
 
@@ -145,15 +145,14 @@ When isHashEnabled is true, `goToStep` accepts a `hashKey` as an argument
 
 ### Use named steps
 
-If we don't need to use hash keys and just simply want to switch steps by their names we can use `namedStepsEnabled`.  
-An example of how `namedStepsEnabled` and `stepName` work together:
+If we don't need to use hash keys and just simply want to switch steps by their names we can use use `stepName`.  
 
 ```jsx
-<StepWizard namedStepsEnabled={true}>
+<StepWizard>
   <BasicInfo stepName={"basic"} />
   <ContactInfo stepName={"contact"} />
   <TermsConditions /> // step3
 </StepWizard>
 ```
 
-When namedStepsEnabled is true, `goToStep` accepts a `stepName` as an argument
+Now we can use `goToNamedStep` and set `stepName` as an argument

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ An example of how `namedStepsEnabled` and `stepName` work together:
 <StepWizard namedStepsEnabled={true}>
   <BasicInfo stepName={"basic"} />
   <ContactInfo stepName={"contact"} />
-  <TermsConditions />
+  <TermsConditions /> // step3
 </StepWizard>
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,16 +143,16 @@ As you can see, the `hashKey` corresponds with the url hash and will be updated 
 
 When isHashEnabled is true, `goToStep` accepts a `hashKey` as an argument
 
-### Use name steps
+### Use named steps
 
 If we don't need to use hash keys and just simply want to switch steps by their names we can use `namedStepsEnabled`.  
 An example of how `namedStepsEnabled` and `stepName` work together:
 
 ```jsx
 <StepWizard namedStepsEnabled={true}>
-  <BasicInfo stepName={"basic"} /> // https://domain.com/#basic
-  <ContactInfo stepName={"contact"} /> // https://domain.com/#contact
-  <TermsConditions /> // https://domain.com/#step3
+  <BasicInfo stepName={"basic"} />
+  <ContactInfo stepName={"contact"} />
+  <TermsConditions />
 </StepWizard>
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ For example:
 | initialStep   | `integer`  | 1         |
 | instance      | `function` |           | Provides an instance of `StepWizard` to control from anywhere in your app                |
 | isHashEnabled | `bool`     | false     | Persists the current step in the URL (hash)                                              |
+| isHashEnabled | `bool`     | false     | Allows for setting names for steps                                                       |
 | isLazyMount   | `boolean`  | false     | Only mounts the child component when `isActive` is true                                  |
 | nav           | `node`     |           | Create a custom navigation component to include in the wizard                            |
 | onStepChange  | `function` |           | Callback for step change                                                                 |
@@ -141,3 +142,18 @@ An example of how `isHashEnabled` and `hashKey` work together:
 As you can see, the `hashKey` corresponds with the url hash and will be updated when the step becomes active. The `hashKey` defaults to `step{n}`. If `isHashEnabled` is `false` then the url hash, or `hashKey`, will not be used.
 
 When isHashEnabled is true, `goToStep` accepts a `hashKey` as an argument
+
+### Use name steps
+
+If we don't need to use hash keys and just simply want to switch steps by their names we can use `namedStepsEnabled`.  
+An example of how `namedStepsEnabled` and `stepName` work together:
+
+```jsx
+<StepWizard namedStepsEnabled={true}>
+  <BasicInfo stepName={"basic"} /> // https://domain.com/#basic
+  <ContactInfo stepName={"contact"} /> // https://domain.com/#contact
+  <TermsConditions /> // https://domain.com/#step3
+</StepWizard>
+```
+
+When namedStepsEnabled is true, `goToStep` accepts a `stepName` as an argument

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -497,116 +497,6 @@ Object {
 }
 `;
 
-exports[`Step Wizard Component namedStepsEnabled - false 1`] = `
-<div
-  className={null}
->
-  <div
-    className="step-wrapper"
-  >
-    <div
-      className="step  active"
-    >
-      <div>
-        Step 1
-      </div>
-    </div>
-    <div
-      className="step"
-    >
-      <div>
-        Step 2
-      </div>
-    </div>
-    <div
-      className="step"
-    >
-      <div>
-        Step 3
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Step Wizard Component namedStepsEnabled - false 2`] = `
-Object {
-  "activeStep": 0,
-  "classes": Object {},
-  "hashKeys": Object {
-    "0": "step1",
-    "1": "step2",
-    "2": "step3",
-    "step1": 0,
-    "step2": 1,
-    "step3": 2,
-  },
-  "namedSteps": Object {
-    "0": "info",
-    "1": "step2",
-    "2": "contact",
-    "contact": 2,
-    "info": 0,
-    "step2": 1,
-  },
-}
-`;
-
-exports[`Step Wizard Component namedStepsEnabled - true 1`] = `
-<div
-  className={null}
->
-  <div
-    className="step-wrapper"
-  >
-    <div
-      className="step  active"
-    >
-      <div>
-        Step 1
-      </div>
-    </div>
-    <div
-      className="step"
-    >
-      <div>
-        Step 2
-      </div>
-    </div>
-    <div
-      className="step"
-    >
-      <div>
-        Step 3
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Step Wizard Component namedStepsEnabled - true 2`] = `
-Object {
-  "activeStep": 0,
-  "classes": Object {},
-  "hashKeys": Object {
-    "0": "step1",
-    "1": "step2",
-    "2": "step3",
-    "step1": 0,
-    "step2": 1,
-    "step3": 2,
-  },
-  "namedSteps": Object {
-    "0": "info",
-    "1": "step2",
-    "2": "contact",
-    "contact": 2,
-    "info": 0,
-    "step2": 1,
-  },
-}
-`;
-
 exports[`Step Wizard Component nav 1`] = `
 <div
   className={null}
@@ -828,10 +718,91 @@ Object {
 }
 `;
 
+exports[`Step Wizard Component with named steps 1`] = `
+<div
+  className={null}
+>
+  <div
+    className="step-wrapper"
+  >
+    <div
+      className="step  active"
+    >
+      <div>
+        Step 1
+      </div>
+    </div>
+    <div
+      className="step"
+    >
+      <div>
+        Step 2
+      </div>
+    </div>
+    <div
+      className="step"
+    >
+      <div>
+        Step 3
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Step Wizard Component with named steps 2`] = `
+Object {
+  "activeStep": 0,
+  "classes": Object {},
+  "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+  "namedSteps": Object {
+    "0": "info",
+    "1": "step2",
+    "2": "contact",
+    "contact": 2,
+    "info": 0,
+    "step2": 1,
+  },
+}
+`;
+
 exports[`Step Wizard Functions firstStep 1`] = `
 Object {
   "activeStep": 0,
   "classes": Object {},
+  "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+}
+`;
+
+exports[`Step Wizard Functions goToNamedStep 1`] = `
+Object {
+  "activeStep": 2,
+  "classes": Object {
+    "0": "animated fadeOutLeft",
+    "2": "animated fadeInRight",
+  },
   "hashKeys": Object {
     "0": "step1",
     "1": "step2",

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -44,6 +44,14 @@ Object {
     "step2": 1,
     "step3": 2,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
 }
 `;
 
@@ -100,6 +108,16 @@ Object {
     "step3": 2,
     "step4": 3,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "3": "step4",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+    "step4": 3,
+  },
 }
 `;
 
@@ -118,6 +136,7 @@ Object {
   "activeStep": 0,
   "classes": Object {},
   "hashKeys": Object {},
+  "namedSteps": Object {},
 }
 `;
 
@@ -164,6 +183,14 @@ Object {
     "First *3@ #$~!,\\";": 0,
     "step2": 1,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
 }
 `;
 
@@ -195,6 +222,12 @@ Object {
   "activeStep": 0,
   "classes": Object {},
   "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "step1": 0,
+    "step2": 1,
+  },
+  "namedSteps": Object {
     "0": "step1",
     "1": "step2",
     "step1": 0,
@@ -240,6 +273,14 @@ Object {
   "activeStep": 1,
   "classes": Object {},
   "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+  "namedSteps": Object {
     "0": "step1",
     "1": "step2",
     "2": "step3",
@@ -294,6 +335,14 @@ Object {
     "step2": 1,
     "step3": 2,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
 }
 `;
 
@@ -340,6 +389,14 @@ Object {
     "First": 0,
     "The End!": 2,
     "step2": 1,
+  },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
   },
 }
 `;
@@ -388,6 +445,14 @@ Object {
     "The End!": 2,
     "step2": 1,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
 }
 `;
 
@@ -420,6 +485,124 @@ Object {
     "step1": 0,
     "step2": 1,
     "step3": 2,
+  },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+}
+`;
+
+exports[`Step Wizard Component namedStepsEnabled - false 1`] = `
+<div
+  className={null}
+>
+  <div
+    className="step-wrapper"
+  >
+    <div
+      className="step  active"
+    >
+      <div>
+        Step 1
+      </div>
+    </div>
+    <div
+      className="step"
+    >
+      <div>
+        Step 2
+      </div>
+    </div>
+    <div
+      className="step"
+    >
+      <div>
+        Step 3
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Step Wizard Component namedStepsEnabled - false 2`] = `
+Object {
+  "activeStep": 0,
+  "classes": Object {},
+  "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+  "namedSteps": Object {
+    "0": "info",
+    "1": "step2",
+    "2": "contact",
+    "contact": 2,
+    "info": 0,
+    "step2": 1,
+  },
+}
+`;
+
+exports[`Step Wizard Component namedStepsEnabled - true 1`] = `
+<div
+  className={null}
+>
+  <div
+    className="step-wrapper"
+  >
+    <div
+      className="step  active"
+    >
+      <div>
+        Step 1
+      </div>
+    </div>
+    <div
+      className="step"
+    >
+      <div>
+        Step 2
+      </div>
+    </div>
+    <div
+      className="step"
+    >
+      <div>
+        Step 3
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Step Wizard Component namedStepsEnabled - true 2`] = `
+Object {
+  "activeStep": 0,
+  "classes": Object {},
+  "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+  "namedSteps": Object {
+    "0": "info",
+    "1": "step2",
+    "2": "contact",
+    "contact": 2,
+    "info": 0,
+    "step2": 1,
   },
 }
 `;
@@ -480,6 +663,14 @@ Object {
     "step2": 1,
     "step3": 2,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
 }
 `;
 
@@ -506,6 +697,10 @@ Object {
   "activeStep": 0,
   "classes": Object {},
   "hashKeys": Object {
+    "0": "step1",
+    "step1": 0,
+  },
+  "namedSteps": Object {
     "0": "step1",
     "step1": 0,
   },
@@ -565,6 +760,16 @@ Object {
     "step3": 2,
     "step4": 3,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "3": "step4",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+    "step4": 3,
+  },
 }
 `;
 
@@ -612,6 +817,14 @@ Object {
     "step2": 1,
     "step3": 2,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
 }
 `;
 
@@ -620,6 +833,14 @@ Object {
   "activeStep": 0,
   "classes": Object {},
   "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+  "namedSteps": Object {
     "0": "step1",
     "1": "step2",
     "2": "step3",
@@ -645,6 +866,14 @@ Object {
     "step2": 1,
     "step3": 2,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
 }
 `;
 
@@ -656,6 +885,14 @@ Object {
     "2": "animated fadeInRight",
   },
   "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+  "namedSteps": Object {
     "0": "step1",
     "1": "step2",
     "2": "step3",
@@ -681,6 +918,14 @@ Object {
     "step2": 1,
     "step3": 2,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
 }
 `;
 
@@ -692,6 +937,14 @@ Object {
     "1": "animated fadeInRight",
   },
   "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+  "namedSteps": Object {
     "0": "step1",
     "1": "step2",
     "2": "step3",
@@ -712,6 +965,12 @@ Object {
     "step1": 0,
     "step2": 1,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "step1": 0,
+    "step2": 1,
+  },
 }
 `;
 
@@ -723,6 +982,12 @@ Object {
     "1": "animated fadeInRight",
   },
   "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "step1": 0,
+    "step2": 1,
+  },
+  "namedSteps": Object {
     "0": "step1",
     "1": "step2",
     "step1": 0,
@@ -747,6 +1012,14 @@ Object {
     "step2": 1,
     "step3": 2,
   },
+  "namedSteps": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
 }
 `;
 
@@ -759,6 +1032,14 @@ Object {
     "2": "animated fadeOutRight",
   },
   "hashKeys": Object {
+    "0": "step1",
+    "1": "step2",
+    "2": "step3",
+    "step1": 0,
+    "step2": 1,
+    "step3": 2,
+  },
+  "namedSteps": Object {
     "0": "step1",
     "1": "step2",
     "2": "step3",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,9 +5,11 @@ export type StepWizardProps = Partial<{
   className: string
 
   hashKey: string
+  stepName: string
   initialStep: number
   instance: (wizard: StepWizardProps) => void
   isHashEnabled: boolean
+  namedStepsEnabled: boolean
   isLazyMount: boolean
   nav: JSX.Element
 
@@ -36,6 +38,7 @@ export type StepWizardChildProps<T extends Record<string, any> = {}> = {
   previousStep: () => void
   goToStep: (step: number) => void
   hashKey?: string
+  stepName?: string
 } & T
 
 export declare function StepWizard(props: StepWizardProps): JSX.Element

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,6 @@ export type StepWizardProps = Partial<{
   initialStep: number
   instance: (wizard: StepWizardProps) => void
   isHashEnabled: boolean
-  namedStepsEnabled: boolean
   isLazyMount: boolean
   nav: JSX.Element
 
@@ -37,6 +36,7 @@ export type StepWizardChildProps<T extends Record<string, any> = {}> = {
   nextStep: () => void
   previousStep: () => void
   goToStep: (step: number) => void
+  goToNamedStep: (step: string) => void
   hashKey?: string
   stepName?: string
 } & T

--- a/src/index.js
+++ b/src/index.js
@@ -158,10 +158,17 @@ export default class StepWizard extends PureComponent {
     goToStep = step => {
         if (this.props.isHashEnabled && typeof step === 'string' && this.state.hashKeys[step] !== undefined) {
             this.setActiveStep(this.state.hashKeys[step]);
-        } else if (this.props.namedStepsEnabled && typeof step === 'string' && this.state.namedSteps[step] !== undefined) {
-            this.setActiveStep(this.state.namedSteps[step]);
         } else {
             this.setActiveStep(step - 1);
+        }
+    };
+
+    /** Go to named step */
+    goToNamedStep = step => {
+        if (typeof step === 'string' && this.state.namedSteps[step] !== undefined) {
+            this.setActiveStep(this.state.namedSteps[step]);
+        } else {
+            console.error(`Cannot find step with name "${step}"`);
         }
     };
 
@@ -225,7 +232,6 @@ StepWizard.propTypes = {
     initialStep: PropTypes.number,
     instance: PropTypes.func,
     isHashEnabled: PropTypes.bool,
-    namedStepsEnabled: PropTypes.bool,
     isLazyMount: PropTypes.bool,
     nav: PropTypes.node,
     onStepChange: PropTypes.func,
@@ -238,7 +244,6 @@ StepWizard.defaultProps = {
     initialStep: 1,
     instance: () => {},
     isHashEnabled: false,
-    namedStepsEnabled: false,
     isLazyMount: false,
     nav: null,
     onStepChange: () => {},

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ export default class StepWizard extends PureComponent {
             activeStep: 0,
             classes: {},
             hashKeys: {},
+            namedSteps: {},
         };
 
         // Set initial classes
@@ -44,6 +45,9 @@ export default class StepWizard extends PureComponent {
             // Create hashKey map
             state.hashKeys[i] = (child.props && child.props.hashKey) || `step${i + 1}`;
             state.hashKeys[state.hashKeys[i]] = i;
+            // Create namedSteps map
+            state.namedSteps[i] = (child.props && child.props.stepName) || `step${i + 1}`;
+            state.namedSteps[state.namedSteps[i]] = i;
         });
 
         // Set activeStep to initialStep if exists
@@ -154,6 +158,8 @@ export default class StepWizard extends PureComponent {
     goToStep = step => {
         if (this.props.isHashEnabled && typeof step === 'string' && this.state.hashKeys[step] !== undefined) {
             this.setActiveStep(this.state.hashKeys[step]);
+        } else if (this.props.namedStepsEnabled && typeof step === 'string' && this.state.namedSteps[step] !== undefined) {
+            this.setActiveStep(this.state.namedSteps[step]);
         } else {
             this.setActiveStep(step - 1);
         }
@@ -219,6 +225,7 @@ StepWizard.propTypes = {
     initialStep: PropTypes.number,
     instance: PropTypes.func,
     isHashEnabled: PropTypes.bool,
+    namedStepsEnabled: PropTypes.bool,
     isLazyMount: PropTypes.bool,
     nav: PropTypes.node,
     onStepChange: PropTypes.func,
@@ -231,6 +238,7 @@ StepWizard.defaultProps = {
     initialStep: 1,
     instance: () => {},
     isHashEnabled: false,
+    namedStepsEnabled: false,
     isLazyMount: false,
     nav: null,
     onStepChange: () => {},

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -106,17 +106,7 @@ describe('Step Wizard Component', () => {
         ));
     });
 
-    it('namedStepsEnabled - true', () => {
-        testComponent((
-            <StepWizard namedStepsEnabled>
-                <Step1 stepName={'info'} />
-                <Step2 />
-                <Step3 stepName={'contact'} />
-            </StepWizard>
-        ));
-    });
-
-    it('namedStepsEnabled - false', () => {
+    it('with named steps', () => {
         testComponent((
             <StepWizard>
                 <Step1 stepName={'info'} />
@@ -275,6 +265,12 @@ describe('Step Wizard Functions', () => {
     it('goToStep with hash', () => {
         const wrapper = basicComponentHashEnabled();
         wrapper.goToStep('step3');
+        takeSnapshot(wrapper.state);
+        expect(wrapper.state.activeStep).toEqual(2);
+    });
+    it('goToNamedStep', () => {
+        const wrapper = basicComponent();
+        wrapper.goToNamedStep('step3');
         takeSnapshot(wrapper.state);
         expect(wrapper.state.activeStep).toEqual(2);
     });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -106,6 +106,26 @@ describe('Step Wizard Component', () => {
         ));
     });
 
+    it('namedStepsEnabled - true', () => {
+        testComponent((
+            <StepWizard namedStepsEnabled>
+                <Step1 stepName={'info'} />
+                <Step2 />
+                <Step3 stepName={'contact'} />
+            </StepWizard>
+        ));
+    });
+
+    it('namedStepsEnabled - false', () => {
+        testComponent((
+            <StepWizard>
+                <Step1 stepName={'info'} />
+                <Step2 />
+                <Step3 stepName={'contact'} />
+            </StepWizard>
+        ));
+    });
+
     it('isLazyMount - true', () => {
         testComponent((
             <StepWizard isLazyMount initialStep={2}>


### PR DESCRIPTION
fixes #38

I've added this feature because it might be useful in some cases., especially in project that I'm currently working at. It's just like `isHashEnabled` feature but simplified

## Changes
- add `namedSeps` to state,
- add `namedStepsEnabled` prop to `<StepWizard>`,
- add `stepName` prop to `<Step>`,
- update `readme`,
- update `snapshot`,
- add test cases,
- update types for `TypeScript`

## Example
```js
<StepWizard namedStepsEnabled={true}>
  <BasicInfo stepName={"basic"} />
  <ContactInfo stepName={"contact"} />
  <TermsConditions /> // step3
</StepWizard>
```